### PR TITLE
Update URL to open when clicking "Check for updates"

### DIFF
--- a/MacMediaKeyForwarder/AppDelegate.m
+++ b/MacMediaKeyForwarder/AppDelegate.m
@@ -426,7 +426,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 
 - ( void ) update
 {
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString: @"http://milgra.com/mac-media-key-forwarder.html"]];
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString: @"https://github.com/quentinlesceller/macmediakeyforwarder/releases"]];
 }
 
 


### PR DESCRIPTION
The current URL is redirecting users to a 404.

We can replace it with the GitHub repo "Releases" section.