### PR TITLE
README: point releases link at current repo/fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can prioritize which app you would like to control or you can go with the de
 
 The app runs in the menu bar.
 
-Download the compiled application from my [Releases](https://github.com/milgra/macmediakeyforwarder/releases).
+Download the compiled application from my [Releases](https://github.com/quentinlesceller/macmediakeyforwarder/releases).
 
 If you want even more control over what you want to control you should try [beardedspice](http://beardedspice.github.io).
 


### PR DESCRIPTION
I noticed the "releases" link points at the original repo, not this fork, which led to momentary confusion because the original repo's latest release is several years old. This PR updates the link to point at releases in _this_ repo.